### PR TITLE
Fix N+1 XCom fetches when iterating a mapped task's lazy sequence

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/lazy_sequence.py
+++ b/task-sdk/src/airflow/sdk/execution_time/lazy_sequence.py
@@ -38,21 +38,42 @@ _XComWrapper = collections.namedtuple("_XComWrapper", "value")
 
 log = structlog.get_logger(logger_name=__name__)
 
+# Forward iteration fetches items in chunks via the slice endpoint instead of
+# one HTTP request per item, to avoid an N+1 sequential-call pattern when a
+# task iterates a mapped upstream task's full XCom output.
+_ITER_CHUNK_SIZE = 50
+
 
 @attrs.define
 class LazyXComIterator(Iterator[T]):
     seq: LazyXComSequence[T]
     index: int = 0
     dir: Literal[1, -1] = 1
+    _buffer: list[T] = attrs.field(init=False, factory=list)
+    _buffer_start: int = attrs.field(init=False, default=0)
 
     def __next__(self) -> T:
         if self.index < 0:
             # When iterating backwards, avoid extra HTTP request
             raise StopIteration()
-        try:
-            val = self.seq[self.index]
-        except IndexError:
-            raise StopIteration from None
+        if self.dir != 1:
+            # Backward iteration is rare and not worth batching; keep the
+            # original per-item lookup for it.
+            try:
+                val = self.seq[self.index]
+            except IndexError:
+                raise StopIteration from None
+            self.index += self.dir
+            return val
+
+        if not self._buffer or self.index >= self._buffer_start + len(self._buffer):
+            self._buffer_start = self.index
+            self._buffer = list(self.seq[self.index : self.index + _ITER_CHUNK_SIZE])
+
+        offset = self.index - self._buffer_start
+        if offset >= len(self._buffer):
+            raise StopIteration()
+        val = self._buffer[offset]
         self.index += self.dir
         return val
 

--- a/task-sdk/tests/task_sdk/execution_time/test_lazy_sequence.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_lazy_sequence.py
@@ -33,7 +33,7 @@ from airflow.sdk.execution_time.comms import (
     XComSequenceIndexResult,
     XComSequenceSliceResult,
 )
-from airflow.sdk.execution_time.lazy_sequence import LazyXComSequence
+from airflow.sdk.execution_time.lazy_sequence import _ITER_CHUNK_SIZE, LazyXComSequence
 from airflow.sdk.execution_time.xcom import resolve_xcom_backend
 
 from tests_common.test_utils.config import conf_vars
@@ -74,26 +74,58 @@ def test_len(mock_supervisor_comms, lazy_sequence):
 
 
 def test_iter(mock_supervisor_comms, lazy_sequence):
+    """Forward iteration fetches items in batches via the slice endpoint, not one-by-one."""
     it = iter(lazy_sequence)
 
     mock_supervisor_comms.send.side_effect = [
-        XComSequenceIndexResult(root="f"),
-        ErrorResponse(error=ErrorType.XCOM_NOT_FOUND, detail={"oops": "sorry!"}),
+        XComSequenceSliceResult(root=["f"]),
+        XComSequenceSliceResult(root=[]),
     ]
     assert list(it) == ["f"]
     mock_supervisor_comms.send.assert_has_calls(
         [
             call(
-                msg=GetXComSequenceItem(
+                GetXComSequenceSlice(
                     key=BaseXCom.XCOM_RETURN_KEY,
                     dag_id="dag",
                     task_id="task",
                     run_id="run",
-                    offset=0,
+                    start=0,
+                    stop=_ITER_CHUNK_SIZE,
+                    step=None,
                 ),
             ),
             call(
-                msg=GetXComSequenceItem(
+                GetXComSequenceSlice(
+                    key=BaseXCom.XCOM_RETURN_KEY,
+                    dag_id="dag",
+                    task_id="task",
+                    run_id="run",
+                    start=1,
+                    stop=1 + _ITER_CHUNK_SIZE,
+                    step=None,
+                ),
+            ),
+        ]
+    )
+
+
+def test_iter_backward_still_uses_per_item_lookup(mock_supervisor_comms, lazy_sequence):
+    """Backward iteration (dir=-1) keeps the original per-item lookup, unaffected by batching."""
+    from airflow.sdk.execution_time.lazy_sequence import LazyXComIterator
+
+    it = LazyXComIterator(seq=lazy_sequence, index=1, dir=-1)
+
+    mock_supervisor_comms.send.side_effect = [
+        XComSequenceIndexResult(root="b"),
+        XComSequenceIndexResult(root="a"),
+        ErrorResponse(error=ErrorType.XCOM_NOT_FOUND, detail={"oops": "sorry!"}),
+    ]
+    assert list(it) == ["b", "a"]
+    mock_supervisor_comms.send.assert_has_calls(
+        [
+            call(
+                GetXComSequenceItem(
                     key=BaseXCom.XCOM_RETURN_KEY,
                     dag_id="dag",
                     task_id="task",
@@ -101,8 +133,28 @@ def test_iter(mock_supervisor_comms, lazy_sequence):
                     offset=1,
                 ),
             ),
+            call(
+                GetXComSequenceItem(
+                    key=BaseXCom.XCOM_RETURN_KEY,
+                    dag_id="dag",
+                    task_id="task",
+                    run_id="run",
+                    offset=0,
+                ),
+            ),
         ]
     )
+
+
+def test_iter_preserves_falsy_values(mock_supervisor_comms, lazy_sequence):
+    """A falsy-but-real item (0, "", False, None) must not be mistaken for an empty/exhausted buffer."""
+    it = iter(lazy_sequence)
+
+    mock_supervisor_comms.send.side_effect = [
+        XComSequenceSliceResult(root=[0, "", False, None, "last"]),
+        XComSequenceSliceResult(root=[]),
+    ]
+    assert list(it) == [0, "", False, None, "last"]
 
 
 def test_getitem_index(mock_supervisor_comms, lazy_sequence):


### PR DESCRIPTION
Forward iteration over LazyXComSequence (task-sdk/src/airflow/sdk/execution_time/lazy_sequence.py) issued one Execution API HTTP request per item. A task iterating a mapped upstream task's full XCom output — directly, or via zip()/concat() on XComArgs — fired a sequential HTTP call per item, which Datadog APM's "Sequential API Calls" detector flagged under airflow-worker's execute_workload span.

[Jira Ticket](https://datadoghq.atlassian.net/jira/software/projects/RECS/boards/31672?jql=assignee%20%3D%20712020%3A8bd8c0fd-01ae-4016-a2cb-f6b363254cc1&selectedIssue=RECS-53)

### What
LazyXComIterator.__next__ now fetches items in chunks (50 at a time) using the existing GetXComSequenceSlice / get_sequence_slice endpoint, instead of one GetXComSequenceItem request per item. This mirrors the batching already used by BaseXCom.get_all().

### How it behaves
- Forward iteration (dir=1, the common case): buffers a chunk via one slice request, refilling as the buffer is   exhausted.
- Backward iteration (dir=-1, rare): unchanged — still one per-item request, since it wasn't worth batching.      - Single-item (seq[i]) and slice (seq[a:b]) a
- No API contract changes — reuses the slice endpoint that already existed and is used elsewhere.                 
### Test plan                                                                                                         
- Rewrote test_iter to assert the new batched-slice call pattern (previously asserted the old per-item calls).    - Added test_iter_backward_still_uses_per_ite had no prior coverage.
- Added test_iter_preserves_falsy_values — guards the buffer-emptiness check against falsy-but-real items (0, "", False, None).
- Ran the full task-sdk test suite; 19 pre-existing failures confirmed unrelated by reproducing them identically on a git stash'd clean tree.
- Ran an independent adversarial review pass (buffer boundary math, slice-vs-item deserialization equivalence,
concurrency/shared-state, error-handling divessues found.

---
Was generative AI tooling used to co-author this PR?

- [x] Yes — Claude Code (Sonnet 5)

Generated-by: Claude Code (Sonnet 5) following the guidelines (https://github.com/apache/airflow/blob/main/requests.rst#gen-ai-assisted-contributions)