### PR TITLE
Fix MessageQueueTrigger queue collision with trigger queue assignment

### DIFF
--- a/providers/common/messaging/src/airflow/providers/common/messaging/triggers/msg_queue.py
+++ b/providers/common/messaging/src/airflow/providers/common/messaging/triggers/msg_queue.py
@@ -58,7 +58,11 @@ class MessageQueueTrigger(BaseEventTrigger):
         :ref:`howto/trigger:MessageQueueTrigger`
     """
 
-    queue: str | None = None
+    # Deprecated broker queue identifier (URI format), e.g. "sqs://...". Stored under a name distinct
+    # from the inherited `queue` attribute, which `BaseEventTrigger` now uses for triggerer queue
+    # assignment (see #71346) — reusing `queue` here would silently leak this URI into that unrelated
+    # triggerer-routing field.
+    queue_uri: str | None = None
     scheme: str | None = None
 
     def __init__(self, *, queue: str | None = None, scheme: str | None = None, **kwargs: Any) -> None:
@@ -73,10 +77,10 @@ class MessageQueueTrigger(BaseEventTrigger):
                 AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
-            self.queue = queue
+            self.queue_uri = queue
             self.scheme = None
         else:
-            self.queue = None
+            self.queue_uri = None
             self.scheme = scheme
 
         self.kwargs = kwargs
@@ -91,12 +95,12 @@ class MessageQueueTrigger(BaseEventTrigger):
             raise ValueError("No message queue providers are available. ")
 
         # Find matching providers based on queue URI or scheme
-        if self.queue is not None:
+        if self.queue_uri is not None:
             # Use existing queue-based matching for backward compatibility
             providers = [
-                provider for provider in MESSAGE_QUEUE_PROVIDERS if provider.queue_matches(self.queue)
+                provider for provider in MESSAGE_QUEUE_PROVIDERS if provider.queue_matches(self.queue_uri)
             ]
-            identifier = self.queue
+            identifier = self.queue_uri
             match_by = "queue"
         elif self.scheme is not None:
             # Use new scheme-based matching
@@ -131,9 +135,9 @@ class MessageQueueTrigger(BaseEventTrigger):
 
         # Create trigger instance
         selected_provider = providers[0]
-        if self.queue is not None:
+        if self.queue_uri is not None:
             # Pass queue to trigger_kwargs for backward compatibility
-            trigger_kwargs = selected_provider.trigger_kwargs(self.queue, **self.kwargs)
+            trigger_kwargs = selected_provider.trigger_kwargs(self.queue_uri, **self.kwargs)
             return selected_provider.trigger_class()(**trigger_kwargs, **self.kwargs)
         # For scheme-based matching, we need to pass all current kwargs to the trigger
         return selected_provider.trigger_class()(**self.kwargs)

--- a/providers/common/messaging/tests/unit/common/messaging/triggers/test_msg_queue.py
+++ b/providers/common/messaging/tests/unit/common/messaging/triggers/test_msg_queue.py
@@ -216,14 +216,27 @@ class TestMessageQueueTriggerScheme:
     def test_queue_takes_precedence_over_scheme(self):
         """Test that queue parameter takes precedence when both are provided."""
         trigger = MessageQueueTrigger(queue=PROVIDER_1_QUEUE, scheme=PROVIDER_2_SCHEME)
-        assert trigger.queue == PROVIDER_1_QUEUE
+        assert trigger.queue_uri == PROVIDER_1_QUEUE
         assert trigger.scheme is None
 
     def test_scheme_only_initialization(self):
         """Test initialization with scheme parameter only."""
         trigger = MessageQueueTrigger(scheme=PROVIDER_2_SCHEME)
-        assert trigger.queue is None
+        assert trigger.queue_uri is None
         assert trigger.scheme == PROVIDER_2_SCHEME
+
+    @pytest.mark.usefixtures("collect_queue_param_deprecation_warning")
+    def test_deprecated_queue_param_does_not_set_triggerer_queue(self):
+        """Regression test: the deprecated `queue` (broker URI) must not leak into the unrelated
+        `BaseEventTrigger.queue` attribute used for triggerer queue assignment (see #71346), or the
+        resulting Trigger row would never be picked up by any triggerer."""
+        trigger = MessageQueueTrigger(queue=PROVIDER_1_QUEUE)
+        assert trigger.queue_uri == PROVIDER_1_QUEUE
+        assert trigger.queue is None
+
+    def test_scheme_param_does_not_set_triggerer_queue(self):
+        trigger = MessageQueueTrigger(scheme=PROVIDER_2_SCHEME)
+        assert trigger.queue is None
 
     def test_scheme_provider_matching(self):
         """Test that scheme matching works correctly."""


### PR DESCRIPTION
## What?
* Renames MessageQueueTrigger's internal storage for its deprecated `queue`
  (broker URI) constructor param from `self.queue` to `self.queue_uri`, so
  it no longer collides with the new `BaseEventTrigger.queue` attribute this
  branch introduces for triggerer queue assignment.
* Adds regression tests confirming the deprecated `queue=`/`scheme=`
  constructor params never populate the new triggerer-routing `.queue`
  attribute.

## Why?
`MessageQueueTrigger.__init__` unconditionally does `self.queue = <broker
URI or None>`, directly overwriting the `queue` attribute this branch adds
to `BaseTrigger` for triggerer-host routing. `MessageQueueTrigger` backs
essentially every real-world AssetWatcher integration (SQS, Kafka, Redis,
Azure Service Bus, IBM MQ, PubSub via common.messaging) — any Dag still
using the documented-but-deprecated `MessageQueueTrigger(queue="https://
sqs.../my-queue")` call style would have that URI persisted into
`Trigger.queue`. Since `ids_for_triggerer`/`get_sorted_triggers` filter on
`queue IS NULL` for any triggerer started without `--queues` (i.e. every
triggerer today, since `--queues` requires `queues_enabled=True`), that
trigger would never be picked up by any triggerer again — silently, with
no error, regardless of whether `queues_enabled` is even turned on.

## Testing
* 2 existing tests updated to assert on the renamed `queue_uri` attribute;
  2 new regression tests confirming `.queue` stays `None` for both the
  deprecated `queue=` and the new `scheme=` construction styles.
* `breeze run pytest providers/common/messaging/tests/unit/common/messaging/triggers/test_msg_queue.py` — 20 passed.

## Additional Notes
Scoped to MessageQueueTrigger only — confirmed via `git grep` it's the only
trigger class in the tree that assigns `self.queue` directly.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

* Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
* Scope of AI use:
    * Found the bug by reading #71346's diff and grepping the provider tree for other `self.queue` assignments.
    * Implemented the fix and tests.